### PR TITLE
[RETAIN-2211] Add thread safety to VCRCassette with dispatch queue

### DIFF
--- a/Sources/VCRURLConnection/include/VCRCassette_Private.h
+++ b/Sources/VCRURLConnection/include/VCRCassette_Private.h
@@ -27,5 +27,6 @@
 
 @property (nonatomic, strong) NSMutableDictionary *responseDictionary;
 @property (nonatomic, strong) NSMutableArray *regexRecordings;
+@property (nonatomic, strong) dispatch_queue_t synchronizationQueue;
 
 @end


### PR DESCRIPTION
This pull request introduces thread safety to the `VCRCassette` class in the `VCRURLConnection` library by synchronizing access to its internal data structures. The changes ensure that operations on `responseDictionary` and `regexRecordings` are safe when accessed from multiple threads, preventing potential data races and inconsistencies.

**Thread safety improvements:**

* Added a new property `synchronizationQueue` to `VCRCassette` and initialized it as a serial dispatch queue for synchronizing access to internal state. [[1]](diffhunk://#diff-149c7d89a39f5bc9be74387df2ad884d12efdb510a13219ed09ca88ba32c14f2R30) [[2]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2R44)
* Wrapped all mutations and accesses to `responseDictionary` and `regexRecordings` (such as in `addRecording:`, `recordingForRequestKey:replaying:`, `JSON`, `isEqual:`, `hash`, and `allKeys`) in `dispatch_async` or `dispatch_sync` blocks to ensure atomic operations. [[1]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2R69) [[2]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2R83-R89) [[3]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2L96-R110) [[4]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2L121-R147) [[5]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2L146-R192)

**Safe enumeration and copying:**

* Created copies of arrays and dictionaries before enumeration within synchronized blocks to prevent mutation during iteration and avoid potential crashes. [[1]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2L96-R110) [[2]](diffhunk://#diff-3f13cfa0b1dc3ff331806a57219af962a82f5a8d1a466f6ff61c0b9b87b5f1f2L121-R147)

These changes make the cassette object safe for concurrent use, which is especially important when running tests or recording/replaying HTTP interactions in multi-threaded environments.